### PR TITLE
Android release APK inclusion

### DIFF
--- a/.cursor/rules/release-checklist.mdc
+++ b/.cursor/rules/release-checklist.mdc
@@ -67,9 +67,11 @@ When pushing significant changes to `staging` that aren't ready for `main`:
 
 ### Android app
 - Merge `staging` → `main`, then tag: `git tag android-vX.Y.Z && git push origin android-vX.Y.Z`
-- Create: `gh release create android-vX.Y.Z "android/dist/openRS_vX.Y.Z.apk#openRS_vX.Y.Z.apk" --title "openRS_ vX.Y.Z — <short description>" --latest --notes "<notes>"`
-- APK must be the **signed** build from `android/dist/`, not debug
+- Create release: `gh release create android-vX.Y.Z --title "openRS_ vX.Y.Z — <short description>" --latest --notes "<notes>"`
+- **APK is attached automatically** by the `publish-release` CI job when the `android-v*` tag is pushed
+- The CI job builds a signed release APK using GitHub Secrets (`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`) — ensure these are configured in the repo settings
 - Release notes must summarise every user-visible change
+- Verify the APK appears on the release page after CI completes
 
 ### Firmware (per device)
 - Tag: `git tag fw-usb-vX.Y && git push origin fw-usb-vX.Y` (and/or `fw-pro-vX.Y`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: CI
 on:
   push:
     branches: [ main, staging ]
+    tags: [ 'android-v*' ]
   pull_request:
     branches: [ main ]
 
@@ -91,3 +92,53 @@ jobs:
           name: openRS-release
           path: android/app/build/outputs/apk/release/*.apk
           retention-days: 30
+
+  publish-release:
+    name: Attach APK to GitHub Release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/android-v')
+    needs: [ build, lint ]
+    permissions:
+      contents: write
+    defaults:
+      run:
+        working-directory: android
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'gradle'
+
+      - name: Decode release keystore
+        if: ${{ secrets.KEYSTORE_BASE64 != '' }}
+        env:
+          KEYSTORE_BASE64: ${{ secrets.KEYSTORE_BASE64 }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        run: |
+          echo "$KEYSTORE_BASE64" | base64 -d > openrs-release.jks
+          cat > keystore.properties <<EOF
+          storeFile=openrs-release.jks
+          storePassword=$KEYSTORE_PASSWORD
+          keyAlias=$KEY_ALIAS
+          keyPassword=$KEY_PASSWORD
+          EOF
+
+      - name: Build release APK
+        run: chmod +x gradlew && ./gradlew assembleRelease --no-daemon
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#android-v}" >> "$GITHUB_OUTPUT"
+
+      - name: Attach APK to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: android/app/build/outputs/apk/release/openRS_v${{ steps.version.outputs.version }}.apk


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Description
Automates the attachment of the signed Android APK to GitHub Releases. Previously, this was a manual and error-prone step, leading to releases (e.g., v2.2.2) missing the APK asset.

This change introduces a new CI job that triggers on `android-v*` tags, builds the signed APK, and attaches it to the corresponding GitHub Release. The release checklist has been updated to reflect this automation and document the necessary GitHub Secrets for signing.

## Type of Change
- [ ] Bug fix
- [x] New feature / parameter
- [x] Documentation update
- [ ] Refactor / performance improvement

## Testing
- [x] Unit tests pass (`./gradlew test`)
- [ ] Tested on phone UI
- [ ] Tested with real WiCAN + Focus RS
- [ ] Browser emulator updated (if UI changed)
- **Note:** This change modifies CI workflows. Full validation requires pushing an `android-v*` tag to trigger the new `publish-release` job and configuring the required GitHub Secrets (`KEYSTORE_BASE64`, `KEYSTORE_PASSWORD`, `KEY_ALIAS`, `KEY_PASSWORD`).

## New PIDs (if applicable)
| PID | ECU | Mode | Formula | Source |
|-----|-----|------|---------|--------|
| | | | | |

## Screenshots
N/A

<div><a href="https://cursor.com/agents/bc-3bc0dc2f-9776-4017-a6ed-8addf74eaf3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3bc0dc2f-9776-4017-a6ed-8addf74eaf3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->